### PR TITLE
Update PyRAT ingestion for true server

### DIFF
--- a/adamacs/ingest/pyrat.py
+++ b/adamacs/ingest/pyrat.py
@@ -169,7 +169,6 @@ class PyratIngestion:
                                  'earmark': animal['labid'],
                                  'sex': animal['sex'],
                                  'birth_date': animal['dateborn'] or None,
-                                 # 'subject_description': ??, # pyrat animal_color?
                                  'generation': animal['generation'] or None,
                                  'parent_ids': parent_ids or None,
                                  'owner_id': owner_id,
@@ -205,8 +204,10 @@ class PyratIngestion:
             subject.SubjectGenotype.insert(genotype_list)
 
     def strain_status(self, strain_id: str):
-        """For a given a given strain_id, return 'active'
-        is_active is the only info uniquely within the strains table
+        """
+        For a given a given strain_id, return 'active'. Within PyRAT, is_active is 
+        only stored in the strains table. If strain does not appear in the strains 
+        table, return unknown.
 
         :param strain_id: strain id from the animal table
         """
@@ -215,9 +216,9 @@ class PyratIngestion:
                                           params=requested_params
                                           ).content)
         
-        # CB Dev note: It seems that all listed strains in PyRAT are 'active'.
-        # Others are are unlisted. Therefore inactive? Emailed Valentin Stein to confirm
-        return payload[0]['active'] if payload else 0
+        active_labels = ['inactive', 'active']
+        
+        return active_labels[payload[0]['active']] if payload else 'unknown'
 
 
 def restrict_by(payload, pkey, dest_table=None, tkey=None):

--- a/adamacs/ingest/pyrat.py
+++ b/adamacs/ingest/pyrat.py
@@ -1,12 +1,14 @@
 """ Work in progress; not ready for use.
-Models: https://pyrat.uniklinik-bonn.de/pyrat-test/api/v2/specification/ui#/models
+Models: https://pyrat.uniklinik-bonn.de/pyrat/api/v2/specification/ui#/
 Updates:
     Currently, SFB team does not expect to query the pyrat database for updates
     If this changes, we should add a table that takes a hash of the item in the payload
     and references a lookup table before updating
 Regularity:
     Currently, SFB team expects to manually enter subjects.
-    In the future, we could make adjustments to run a chronjob on a set of IDs
+    In the future, we could make adjustments to run a chronjob on a set of IDs.
+    Or, we could add an upstream table of IDs that need to be entered, with a populate
+    command that called this script.
 Post to pyrat: future updates may include posting deathdate information
     Currently, we do not have write permissions to do so
 Issues that required changes to schema:
@@ -16,32 +18,34 @@ Issues that required changes to schema:
        with unique IDs, and because adamacs may want to track users not associated with
        the animal management facility, we propose assigning an int as adamacs user_id,
        which can be projected up to the animal table as either owner or responsible.
-    3. by projecting up from user_id, we eliminate the need for a separate user_role
+    3. By projecting up from user_id, we eliminate the need for a separate user_role
        table that would have handled 'responsible' and 'owner' - Are there any other
        roles we'd like to keep track of? roles as unique pairing of subject and user
        seem unqiue to the pyrat owner/responsible definitions.
     4. Project is not available via pyrat, so could not be linked to subject
-Issues with pyrat test database:
-    1. None of the available animals have generation information, making it hard to see
-       potential variability in this info.
-    2. A number of test subjects are missing crucial data like birthdate. For now,
-       these variables have been set as nullable, but should be enforced when we have
-       access to the real server.
-Issues with current code:
-    1. mutations_list needs additional logic to prevent adding duplicates for unqiue
-       pairs of line/mutation_id
 
-Example payload= (note( HSC prefix has mutation data))
-    [{'eartag_or_id': 'ROE-0221', 'labid': None, 'sex': 'f', 'generation': None,
-      'dateborn': '2017-04-10T00:00:00', 'strain_name': 'Test_2',
-      'mutations': [{'animalid': 17984, 'mutation_id': 66,
-                     'mutationname': 'cbl-b', 'grade_id': 3,'mutationgrade': '+/+'}],
-      'parents': [{'animalid': 17888, 'parent_id': 14816,
-                   'parent_eartag': 'ROE-0138', 'parent_sex': 'm'},
-                  {'animalid': 17888,'parent_id': 17199,
-                   'parent_eartag': 'ROE-0182', 'parent_sex': 'f'}],
-      'licence_number': None, 'licence_title': None,
-      'owner_fullname': 'Röll Wilhelm', 'responsible_fullname': None}]
+example_payload = 
+    {'eartag_or_id': 'ROS-1371',
+     'labid': 'T499',
+     'sex': 'f',
+     'dateborn': '2022-03-04T00:00:00',
+     'strain_id': 81,
+     'strain_name': 'C57BL6/ N',
+     'mutations': [],
+     'generation': 'F5 c',
+     'parents': [
+         {'animalid': 391639,
+          'parent_id': 345589,
+          'parent_eartag': 'WEZ-8667',
+          'parent_sex': 'm'},
+         {'animalid': 391639,
+          'parent_id': 345595,
+          'parent_eartag': 'WEZ-8673',
+          'parent_sex': 'f'}],
+     'licence_number': '02_Zucht',
+     'licence_title': 'Zucht',
+     'owner_fullname': 'Rose Tobias',
+     'responsible_fullname': 'Kück Laura'}
 """
 
 import datajoint as dj
@@ -51,7 +55,8 @@ from requests.auth import HTTPBasicAuth
 from ..schemas import subject
 
 # Constants
-url = 'https://pyrat.uniklinik-bonn.de/pyrat-test/api/v2/'
+url_test = 'https://pyrat.uniklinik-bonn.de/pyrat-test/api/v2/'
+url = 'https://pyrat.uniklinik-bonn.de/pyrat/api/v2/'
 
 
 class PyratIngestion:
@@ -64,7 +69,7 @@ class PyratIngestion:
         # Establish Authentication
         global auth
         auth = HTTPBasicAuth(dj.config['custom']['pyrat_client_token'],
-                             dj.config['custom']['pyrat_user_token'])
+                                dj.config['custom']['pyrat_user_token'])
 
         # Establish Connection
         test_connection = requests.get(url + 'version', auth=auth)
@@ -72,6 +77,14 @@ class PyratIngestion:
             print('Connected')
         else:
             print(f'Connection error {test_connection.status_code}')
+
+        # Verify Credentials
+        test_credentials = json.loads(requests.get(url + 'credentials', auth=auth
+                                                  ).content)
+        credentials_error = ("Credentials issue: %s invalid.\nPlease contact the "
+                             "animal management facility admin")
+        assert test_credentials['client_valid'], credentials_error % 'client'
+        assert test_credentials['user_valid'], credentials_error % 'user'
 
     def ingest_animal(self, SubjectID: str, prompt=True):
         """Import subject info from pyrat into adamacs subject schema
@@ -89,6 +102,10 @@ class PyratIngestion:
         payload = json.loads(requests.get(url+'animals', auth=auth,
                                           params=requested_params
                                           ).content)
+
+        if not payload: # If no entries, exit
+            print(f'Found no entries for {SubjectID}')
+            return
 
         print('Gathering users...')
         user_list = [{'user_id': 0, 'name': 'default_id'}]
@@ -168,7 +185,7 @@ class PyratIngestion:
         # --- User Confirmation ---
         print('--- PyRAT items to be inserted ---')
         inserts = [user_list, protocol_list, line_list, mutation_list, subject_list]
-        print_key = ['name', 'protocol_description', 'line_name', 'description',
+        print_key = ['name', 'protocol', 'line_name', 'description',
                      'subject']
         titles = ['User(s)', 'Protocol(s)', 'Line(s)', 'Mutation(s)', 'Subjects']
         for insert, key, title in zip(inserts, print_key, titles):
@@ -197,7 +214,10 @@ class PyratIngestion:
         payload = json.loads(requests.get(url+'strains', auth=auth,
                                           params=requested_params
                                           ).content)
-        return payload[0]['active']
+        
+        # CB Dev note: It seems that all listed strains in PyRAT are 'active'.
+        # Others are are unlisted. Therefore inactive? Emailed Valentin Stein to confirm
+        return payload[0]['active'] if payload else 0
 
 
 def restrict_by(payload, pkey, dest_table=None, tkey=None):

--- a/adamacs/pipeline.py
+++ b/adamacs/pipeline.py
@@ -1,7 +1,7 @@
 from . import db_prefix
 
 __all__ = ['subject', 'surgery', 'session', 'behavior', 'equipment', 'scan', 'imaging',
-           'train', 'model',
+           'train', 'model', 'trial', 'event',
            'Equipment', 'Location', 'Subject', 'Project', 'Lab', 'User',
            'Session',
            'get_session_dir', 'get_bpod_root_data_dir', 'get_dlc_root_data_dir',

--- a/adamacs/schemas/subject.py
+++ b/adamacs/schemas/subject.py
@@ -42,10 +42,10 @@ class Protocol(dj.Manual):
 class Line(dj.Manual):
     definition = """
     # animal line 
-    line                        : int
+    line                        : int  # strain_id within PyRAT. Not name_id seen in GUI
     ---
     line_name=''                : varchar(64)
-    is_active                   : int           # bool: 1==True, active
+    is_active                   : enum('active','inactive','unknown')
     """
 
 
@@ -81,7 +81,6 @@ class Subject(dj.Manual):
     earmark                 : varchar(16)     #
     sex                     : enum('M', 'F', 'U')  # Geschlecht
     birth_date              : varchar(32)          # Geb.
-    subject_description=''  : varchar(1024)
     generation=''           : varchar(64)     # Generation (F2 in example sheet)
     parent_ids              : tinyblob        # dict of parent_sex: parent_eartag
     -> User.proj(owner_id='user_id')          # Besitzer

--- a/adamacs/schemas/subject.py
+++ b/adamacs/schemas/subject.py
@@ -34,7 +34,7 @@ class Protocol(dj.Manual):
     # PyRAT licence number and title
     protocol                        : varchar(32)
     ---
-    protocol_description=''         : varchar(64)
+    protocol_description=''         : varchar(255)
     """
 
 
@@ -45,7 +45,7 @@ class Line(dj.Manual):
     line                        : int
     ---
     line_name=''                : varchar(64)
-    is_active                   : int
+    is_active                   : int           # bool: 1==True, active
     """
 
 
@@ -76,18 +76,18 @@ class Subject(dj.Manual):
     # Our Animals are not uniquely identified by their ID
     # because different labs use different animal facilities.
 
-    subject                 : varchar(16)  # PyRat import uses this for earmark value
+    subject                 : varchar(16)     # PyRat import uses this for earmark value
     ---
-    earmark=''              : varchar(16)  #
+    earmark                 : varchar(16)     #
     sex                     : enum('M', 'F', 'U')  # Geschlecht
-    birth_date=''           : varchar(32) # date  # Geb.
+    birth_date              : varchar(32)          # Geb.
     subject_description=''  : varchar(1024)
     generation=''           : varchar(64)     # Generation (F2 in example sheet)
-    parent_ids=NULL         : tinyblob        # dict of parent_sex: parent_eartag
-    -> [nullable] User.proj(owner_id='user_id')          # Besitzer
-    -> [nullable] User.proj(responsible_id='user_id')    # Verantwortlicher
-    -> [nullable] Line                 # Linie / Stamm
-    -> [nullable] Protocol
+    parent_ids              : tinyblob        # dict of parent_sex: parent_eartag
+    -> User.proj(owner_id='user_id')          # Besitzer
+    -> User.proj(responsible_id='user_id')    # Verantwortlicher
+    -> Line                                   # Linie / Stamm
+    -> Protocol
     """
 
 
@@ -97,9 +97,8 @@ class SubjectGenotype(dj.Manual):
     -> Subject
     -> Mutation
     ---
-    genotype        : enum('wt/wt', 'wt/tg', 'tg/wt', 'tg/tg', 'cre+', '+/-')
+    genotype        : enum('wt/wt', 'wt/tg', 'tg/wt', 'tg/tg')
     """
-    # CB DEV NOTE: added 'cre+' and '+/-' to reflect pyrat sample database
 
 
 @schema
@@ -107,6 +106,6 @@ class SubjectDeath(dj.Manual):
     definition = """
     -> Subject
     ---
-    death_date      : date       # death date
-    cause           :    varchar(255)
+    death_date      : date
+    cause           : varchar(255)
     """

--- a/notebooks/03_pyrat_insert.ipynb
+++ b/notebooks/03_pyrat_insert.ipynb
@@ -89,6 +89,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Deleting 1 rows from `bonn_subject`.`subject_genotype`\n",
+      "Deleting 5 rows from `bonn_subject`.`subject`\n",
+      "Deleting 2 rows from `bonn_subject`.`#user`\n",
+      "Deletes committed.\n",
+      "Deleting 3 rows from `bonn_subject`.`protocol`\n",
+      "Deletes committed.\n",
+      "Deleting 1 rows from `bonn_subject`.`mutation`\n",
+      "Deleting 2 rows from `bonn_subject`.`line`\n",
+      "Deletes committed.\n",
+      "Deleting 0 rows from `bonn_subject`.`subject`\n",
+      "Nothing to delete.\n",
       "User 0\n",
       "Protocol 0\n",
       "Line 0\n",
@@ -99,8 +110,8 @@
     }
    ],
    "source": [
-    "# subject.User.delete(); subject.Protocol.delete()\n",
-    "# subject.Line.delete(); subject.Subject.delete()\n",
+    "subject.User.delete(); subject.Protocol.delete()\n",
+    "subject.Line.delete(); subject.Subject.delete()\n",
     "print('User', len(subject.User()))\n",
     "print('Protocol', len(subject.Protocol()))\n",
     "print('Line', len(subject.Line()))\n",
@@ -118,29 +129,17 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "cc50c2bb-a03f-46b7-83f5-492d63fa0081",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from adamacs.ingest.pyrat import PyratIngestion"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "b44bbdd6-536d-41e5-87b5-1820a631f1bf",
    "metadata": {},
    "source": [
-    "This function permits wildcards when querying [the API](https://pyrat.uniklinik-bonn.de/pyrat-test/api/v2/specification/ui#/Listing/get_animals).\n",
-    "\n",
     "The function is designed to list all proposed insertions and ask for a confirmation before entered into the schema."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "d8410737-51f6-495d-ae0c-d25fddca3503",
+   "execution_count": 3,
+   "id": "cc50c2bb-a03f-46b7-83f5-492d63fa0081",
    "metadata": {},
    "outputs": [
     {
@@ -153,66 +152,64 @@
       "Gathering lines/mutations...\n",
       "Gathering subjects...\n",
       "--- PyRAT items to be inserted ---\n",
-      "User(s):  ['Schorle Hubert', 'Egert Angela'] \n",
+      "User(s):  ['Rose Tobias', 'Kück Laura'] \n",
       "\n",
-      "Protocol(s):  [] \n",
+      "Protocol(s):  ['02_Zucht'] \n",
       "\n",
-      "Line(s):  ['B6-R26RLacZ', '129-Sox2-Cre', '129-Blimp1Venus', '129SV/S2', 'B6-Eomes-GFP', 'C57BL6/J', 'PSA-Cre', '129-TNAP-Cre N12', '129-Vasa-Cre'] \n",
+      "Line(s):  ['C57BL6/ N'] \n",
       "\n",
-      "Mutation(s):  ['Reporter', 'Sox2-Cre', 'Reporter', 'PSA-Cre', 'Vasa-Cre'] \n",
+      "Mutation(s):  [] \n",
       "\n",
-      "Subjects:  ['HSC-0101', 'HSC-0102', 'HSC-0103', 'HSC-0104', 'HSC-0106', 'HSC-0113', 'HSC-0114', 'HSC-0115', 'HSC-0116', 'HSC-0118', 'HSC-0119', 'HSC-0120', 'HSC-0121', 'HSC-0129', 'HSC-0130', 'HSC-0131', 'HSC-0142', 'HSC-0143', 'HSC-0149', 'HSC-0158', 'HSC-0159', 'HSC-0168', 'HSC-0171', 'HSC-0172', 'HSC-0199'] \n",
+      "Subjects:  ['ROS-1371'] \n",
       "\n"
-     ]
-    },
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      "Proceed with new subject(s) insert? [yes, no]:  yes\n"
      ]
     }
    ],
    "source": [
-    "PyratIngestion().ingest_animal(\"HSC-01*\")"
+    "from adamacs.schemas import subject\n",
+    "from adamacs.ingest.pyrat import PyratIngestion\n",
+    "PyratIngestion().ingest_animal(\"ROS-1371\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8410737-51f6-495d-ae0c-d25fddca3503",
+   "metadata": {},
+   "source": [
+    "This function also permits wildcards when querying [the API](https://pyrat.uniklinik-bonn.de/pyrat-test/api/v2/specification/ui#/Listing/get_animals)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "c73859df-74c8-4335-8002-dcc44a1eaa9d",
+   "execution_count": 4,
+   "id": "a24dce2c",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "User 2\n",
-      "Protocol 0\n",
-      "Line 9\n",
-      "Mutation 5\n",
-      "Subject 25\n",
-      "SubjectGenotype 14\n"
+      "Connected\n",
+      "Gathering users...\n",
+      "Gathering protocols...\n",
+      "Gathering lines/mutations...\n",
+      "Gathering subjects...\n",
+      "--- PyRAT items to be inserted ---\n",
+      "User(s):  [] \n",
+      "\n",
+      "Protocol(s):  ['81-02.04.2019.A193', '81-02.04.2018.A006'] \n",
+      "\n",
+      "Line(s):  ['Gcamp6-Thy'] \n",
+      "\n",
+      "Mutation(s):  ['Tg(Thy1-GCaMP6s)'] \n",
+      "\n",
+      "Subjects:  ['ROS-1375', 'ROS-1377', 'ROS-1378', 'ROS-1379'] \n",
+      "\n"
      ]
     }
    ],
    "source": [
-    "print('User', len(subject.User()))\n",
-    "print('Protocol', len(subject.Protocol()))\n",
-    "print('Line', len(subject.Line()))\n",
-    "print('Mutation', len(subject.Mutation()))\n",
-    "print('Subject', len(subject.Subject()))\n",
-    "print('SubjectGenotype', len(subject.SubjectGenotype()))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9e19a41b-aefb-49ee-8ec5-06c8ff93124e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "PyratIngestion().ingest_animal(\"HSC-02*\")"
+    "PyratIngestion().ingest_animal(\"ROS-137*\")"
    ]
   },
   {
@@ -225,10 +222,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "a0d7be9c-e166-41cf-a04f-99cea903378d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "User 2\n",
+      "Protocol 3\n",
+      "Line 2\n",
+      "Mutation 1\n",
+      "Subject 5\n",
+      "SubjectGenotype 1\n"
+     ]
+    }
+   ],
    "source": [
     "print('User', len(subject.User()))\n",
     "print('Protocol', len(subject.Protocol()))\n",
@@ -248,13 +258,16 @@
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "e03316d7406bfb98090c8573fede251cd5a78124d7abd2c3856cf1ca706a834d"
+  },
   "jupytext": {
    "formats": "ipynb,py"
   },
   "kernelspec": {
-   "display_name": "bonn",
+   "display_name": "Python 3.8.2 ('bonn')",
    "language": "python",
-   "name": "bonn"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -266,7 +279,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/py_scripts/03_pyrat_insert.py
+++ b/notebooks/py_scripts/03_pyrat_insert.py
@@ -8,9 +8,9 @@
 #       format_version: '1.5'
 #       jupytext_version: 1.13.7
 #   kernelspec:
-#     display_name: bonn
+#     display_name: Python 3.8.2 ('bonn')
 #     language: python
-#     name: bonn
+#     name: python3
 # ---
 
 # # PyRAT subject ingestion
@@ -38,8 +38,8 @@ dj.conn()
 
 # ## Initial check of tables
 
-# subject.User.delete(); subject.Protocol.delete()
-# subject.Line.delete(); subject.Subject.delete()
+subject.User.delete(); subject.Protocol.delete()
+subject.Line.delete(); subject.Subject.delete()
 print('User', len(subject.User()))
 print('Protocol', len(subject.Protocol()))
 print('Line', len(subject.Line()))
@@ -49,22 +49,15 @@ print('SubjectGenotype', len(subject.SubjectGenotype()))
 
 # ## Automated ingestion
 
-from adamacs.ingest.pyrat import PyratIngestion
-
-# This function permits wildcards when querying [the API](https://pyrat.uniklinik-bonn.de/pyrat-test/api/v2/specification/ui#/Listing/get_animals).
-#
 # The function is designed to list all proposed insertions and ask for a confirmation before entered into the schema.
 
-PyratIngestion().ingest_animal("HSC-01*")
+from adamacs.schemas import subject
+from adamacs.ingest.pyrat import PyratIngestion
+PyratIngestion().ingest_animal("ROS-1371")
 
-print('User', len(subject.User()))
-print('Protocol', len(subject.Protocol()))
-print('Line', len(subject.Line()))
-print('Mutation', len(subject.Mutation()))
-print('Subject', len(subject.Subject()))
-print('SubjectGenotype', len(subject.SubjectGenotype()))
+# This function also permits wildcards when querying [the API](https://pyrat.uniklinik-bonn.de/pyrat-test/api/v2/specification/ui#/Listing/get_animals).
 
-PyratIngestion().ingest_animal("HSC-02*")
+PyratIngestion().ingest_animal("ROS-137*")
 
 # ## Confirm entry
 


### PR DESCRIPTION
adamacs/pyrat/ingest.py:
- Header comments: Update to reflect status quo
- __init__: Add assertions for credentials
- ingest_animal: Return if query payload is empty i.e. no animals
- ingest_animal: Print protocol instead of description on confirmation
- strain_status: handle no strain entry as inactive
                 emailed to confirm this logic

adamacs/pipeline.py: added items to `__all__`

adamacs/schemas/subject.py
- Protocol: Expanded description varchar length 
- Subject: removed 'permit null' where all true database examples had values
- SubjectGenotype: removed test database temporary entries and dev note
- SubjectDeath: removed redundant comment

notebooks/03 ipynb and py: revised with values from true database